### PR TITLE
Extending fshift

### DIFF
--- a/vcfloat/FPLang.v
+++ b/vcfloat/FPLang.v
@@ -597,6 +597,36 @@ Proof.
   typeclasses eauto.
 Qed.
 
+(* AEK 12/2021 *)
+Lemma cast_not_is_nan tfrom tto:
+  type_le tfrom tto ->
+  forall f,
+  is_nan _ _ f = false ->
+  is_nan _ _ (cast tto tfrom f) = false.
+Proof.
+  unfold cast.
+  intros.
+  destruct (type_eq_dec tfrom tto).
+  {
+    subst. assumption.
+  }
+  destruct H.
+  destruct f. 
+  {
+  simpl. auto.
+  }
+  { 
+  simpl. auto.
+  }
+  { 
+  simpl. auto.
+  }
+  apply is_finite_not_is_nan. 
+  apply Bconv_widen_exact; auto with zarith.
+  typeclasses eauto.
+Qed.
+(* end AEK *)
+
 Lemma cast_eq tfrom tto:
   type_le tfrom tto ->
   forall f,

--- a/vcfloat/FPLang.v
+++ b/vcfloat/FPLang.v
@@ -3143,6 +3143,32 @@ Proof.
   typeclasses eauto.
 Qed.
 
+Lemma cast_is_nan tfrom tto:
+  type_le tfrom tto ->
+  forall f,
+  is_nan _ _ f = true ->
+  is_nan _ _ (cast tto tfrom f) = true.
+Proof.
+  unfold cast.
+  intros.
+  destruct (type_eq_dec tfrom tto).
+  {
+    subst. assumption.
+  }
+  destruct H;
+  destruct f.
+  {
+  simpl in H0; auto.
+  }
+  { 
+  simpl in H0; auto.
+  }
+  { 
+  simpl. auto.
+  }
+  simpl in H0; auto.
+Qed.
+
 (* end - AEK additions for fshift_div correct *)
 
 Lemma Bmult_correct_comm:

--- a/vcfloat/FPLang.v
+++ b/vcfloat/FPLang.v
@@ -3169,6 +3169,32 @@ Proof.
   simpl in H0; auto.
 Qed.
 
+Lemma cast_inf tfrom tto:
+  type_le tfrom tto ->
+  forall f,
+  is_finite _ _ f = false ->
+  is_finite _ _ (cast tto tfrom f) = false.
+Proof.
+  unfold cast.
+  intros.
+  destruct (type_eq_dec tfrom tto).
+  {
+    subst. assumption.
+  }
+  destruct H;
+  destruct f.
+  {
+  simpl in H0; auto.
+  }
+  { 
+  simpl in H0; auto.
+  }
+  { 
+  simpl. auto.
+  }
+  simpl in H0; discriminate. 
+Qed.
+
 (* end - AEK additions for fshift_div correct *)
 
 Lemma Bmult_correct_comm:

--- a/vcfloat/FPLang.v
+++ b/vcfloat/FPLang.v
@@ -597,35 +597,6 @@ Proof.
   typeclasses eauto.
 Qed.
 
-(* AEK 12/2021 *)
-Lemma cast_not_is_nan tfrom tto:
-  type_le tfrom tto ->
-  forall f,
-  is_nan _ _ f = false ->
-  is_nan _ _ (cast tto tfrom f) = false.
-Proof.
-  unfold cast.
-  intros.
-  destruct (type_eq_dec tfrom tto).
-  {
-    subst. assumption.
-  }
-  destruct H.
-  destruct f. 
-  {
-  simpl. auto.
-  }
-  { 
-  simpl. auto.
-  }
-  { 
-  simpl. auto.
-  }
-  apply is_finite_not_is_nan. 
-  apply Bconv_widen_exact; auto with zarith.
-  typeclasses eauto.
-Qed.
-(* end AEK *)
 
 Lemma cast_eq tfrom tto:
   type_le tfrom tto ->
@@ -3083,7 +3054,7 @@ Proof.
 Qed.
 
 
-(* BEGIN - AEK additions for fshift_div correct *)
+(* begin - AEK additions for fshift_div correct *)
 Theorem Bdiv_mult_inverse_finite ty:
   forall x y z: (Binary.binary_float (fprec ty) (femax ty)),
 is_finite _ _ x = true ->
@@ -3143,7 +3114,36 @@ rewrite E in HMUL.
 revert H3.
 rewrite HMUL, HDIV; auto.
 Qed.
-(* END - AEK additions for fshift_div correct *)
+
+Lemma cast_not_is_nan tfrom tto:
+  type_le tfrom tto ->
+  forall f,
+  is_nan _ _ f = false ->
+  is_nan _ _ (cast tto tfrom f) = false.
+Proof.
+  unfold cast.
+  intros.
+  destruct (type_eq_dec tfrom tto).
+  {
+    subst. assumption.
+  }
+  destruct H;
+  destruct f.
+  {
+  simpl. auto.
+  }
+  { 
+  simpl. auto.
+  }
+  { 
+  simpl. auto.
+  }
+  apply is_finite_not_is_nan. 
+  apply Bconv_widen_exact; auto with zarith.
+  typeclasses eauto.
+Qed.
+
+(* end - AEK additions for fshift_div correct *)
 
 Lemma Bmult_correct_comm:
 forall (prec emax : Z) (prec_gt_0_ : FLX.Prec_gt_0 prec)

--- a/vcfloat/FPLang.v
+++ b/vcfloat/FPLang.v
@@ -3083,7 +3083,7 @@ Proof.
 Qed.
 
 
-(* BEGIN - A.E.K additions for fshift_div correct *)
+(* BEGIN - AEK additions for fshift_div correct *)
 Theorem Bdiv_mult_inverse_finite ty:
   forall x y z: (Binary.binary_float (fprec ty) (femax ty)),
 is_finite _ _ x = true ->
@@ -3143,7 +3143,7 @@ rewrite E in HMUL.
 revert H3.
 rewrite HMUL, HDIV; auto.
 Qed.
-(* END - A.E.K additions for fshift_div correct *)
+(* END - AEK additions for fshift_div correct *)
 
 Lemma Bmult_correct_comm:
 forall (prec emax : Z) (prec_gt_0_ : FLX.Prec_gt_0 prec)

--- a/vcfloat/FPLangOpt.v
+++ b/vcfloat/FPLangOpt.v
@@ -1324,23 +1324,174 @@ induction e.
                 unfold BPLUS, BINOP.
                 symmetry in IHe1. symmetry in IHe2. 
                 pose proof type_lub_left (type_of_expr e1) (type_of_expr e2).
-                pose proof type_lub_right (type_of_expr e1) (type_of_expr e2).
                 set (ty:=(type_lub (type_of_expr e1) (type_of_expr e2))) in *.
                 pose proof cast_is_nan (type_of_expr e1)
                 ty H (fval env e1) IHe1.
                 set (x:= cast ty (type_of_expr e1) (fval env e1)) in *.
                 set (y:= cast ty (type_of_expr e2) (fval env e2)) in *.
                 destruct x.
-                  { simpl in H1; discriminate.
+                  { simpl in H0; discriminate.
                   }
-                  { simpl in H1; discriminate.
+                  { simpl in H0; discriminate.
                   }
                   { cbv [Binary.Bplus]; simpl; auto.
                   }
-                  { simpl in H1; discriminate.
+                  { simpl in H0; discriminate.
                   }
+          }
+          { destruct (is_nan_expr env e2).
+            {
+              unfold BPLUS, BINOP.
+              symmetry in IHe1. symmetry in IHe2. 
+              pose proof type_lub_right (type_of_expr e1) (type_of_expr e2).
+              set (ty:=(type_lub (type_of_expr e1) (type_of_expr e2))) in *.
+              pose proof cast_is_nan (type_of_expr e2)
+              ty H (fval env e2) IHe2.
+              set (x:= cast ty (type_of_expr e1) (fval env e1)) in *.
+              set (y:= cast ty (type_of_expr e2) (fval env e2)) in *.
+              destruct x. 
+                { destruct y.
+                  { simpl in H0; discriminate.
+                  }
+                  { simpl in H0; discriminate.
+                  }
+                  { cbv [Binary.Bplus]; simpl; auto.
+                  }
+                  { simpl in H0; discriminate.
+                  }
+                } 
+                { destruct y.
+                  { simpl in H0; discriminate.
+                  }
+                  { simpl in H0; discriminate.
+                  }
+                  { cbv [Binary.Bplus]; simpl; auto.
+                  }
+                  { simpl in H0; discriminate.
+                  }
+                }
+                { destruct y.
+                  { simpl in H0; discriminate.
+                  }
+                  { simpl in H0; discriminate.
+                  }
+                  { cbv [Binary.Bplus]; simpl; auto.
+                  }
+                  { simpl in H0; discriminate.
+                  }
+                }
+                { destruct y.
+                  { simpl in H0; discriminate.
+                  }
+                  { simpl in H0; discriminate.
+                  }
+                  { cbv [Binary.Bplus]; simpl; auto.
+                  }
+                  { simpl in H0; discriminate.
+                  }
+                }
+            }
+              unfold BPLUS, BINOP.
+              symmetry in IHe1. symmetry in IHe2. 
+              pose proof type_lub_left (type_of_expr e1) (type_of_expr e2).
+              pose proof type_lub_right (type_of_expr e1) (type_of_expr e2).
+              set (ty:=(type_lub (type_of_expr e1) (type_of_expr e2))) in *.
+              destruct (fval env e1).
+              { 
+                set (x':=(Binary.B754_zero (fprec (type_of_expr e1)) (femax (type_of_expr e1)) s)) in *.
+                assert (Binary.is_finite (fprec (type_of_expr e1)) (femax (type_of_expr e1)) x' = true) by
+                  (simpl;auto).
+                pose proof cast_finite (type_of_expr e1) ty H x' H1.  
+                set (x:= cast ty (type_of_expr e1) x') in *.
+                destruct x. 
+                  { 
+                  destruct (fval env e2).
+                   {  
+                      set (y':=(Binary.B754_zero (fprec (type_of_expr e2)) (femax (type_of_expr e2)) s1)) in *.
+                      assert (Binary.is_finite (fprec (type_of_expr e2)) (femax (type_of_expr e2)) y' = true) by
+                        (simpl;auto).
+                      pose proof cast_finite (type_of_expr e2) ty H0 y' H3.  
+                      set (y:= cast ty (type_of_expr e2) y') in *.
+                      destruct y. 
+                        { cbv [Binary.Bplus]; simpl; destruct (eqb s0 s2); auto.
+                        }
+                        { simpl in H4; discriminate.
+                        }
+                        { simpl in H4; discriminate.
+                        }
+                        { cbv [Binary.Bplus]; simpl; auto. 
+                        }
+                    }
+                    {
+                      set (y':=(Binary.B754_infinity (fprec (type_of_expr e2)) (femax (type_of_expr e2)) s1)) in *.
+                      assert (Binary.is_finite (fprec (type_of_expr e2)) (femax (type_of_expr e2)) y' = false) by
+                        (simpl;auto).
+                      pose proof cast_not_is_nan (type_of_expr e2) ty H0 y' IHe2.  
+                      pose proof cast_inf (type_of_expr e2) ty H0 y' H3.  
+                      set (y:= cast ty (type_of_expr e2) y') in *.
+                      destruct y. 
+                        { simpl in H5; discriminate.
+                        }
+                        { cbv [Binary.Bplus]; simpl; auto.
+                        }
+                        { simpl in H4; discriminate.
+                        }
+                        { simpl in H5; discriminate.
+                        }
+                     } 
+                     { simpl in IHe2; discriminate. 
+                     }
+                     {
+                      set (y':=(Binary.B754_finite (fprec (type_of_expr e2)) (femax (type_of_expr e2)) s1 m e e0))in *.
+                      assert (Binary.is_finite (fprec (type_of_expr e2)) (femax (type_of_expr e2)) y' = true) by
+                        (simpl;auto).
+                      pose proof cast_finite (type_of_expr e2) ty H0 y' H3.  
+                      set (y:= cast ty (type_of_expr e2) y') in *.
+                      destruct y. 
+                        { cbv [Binary.Bplus]; simpl; destruct (eqb s0 s2); auto.
+                        }
+                        { simpl in H4; discriminate.
+                        }
+                        { simpl in H4; discriminate.
+                        }
+                        { cbv [Binary.Bplus]; simpl; auto. 
+                        }
+                      }
+                  }
+                  { simpl in H2; discriminate.
+                  }
+                  { simpl in H2; discriminate.
+                  } 
+                  destruct (fval env e2).
+                   {  
+                      set (y':=(Binary.B754_zero (fprec (type_of_expr e2)) (femax (type_of_expr e2)) s1)) in *.
+                      assert (Binary.is_finite (fprec (type_of_expr e2)) (femax (type_of_expr e2)) y' = true) by
+                        (simpl;auto).
+                      pose proof cast_finite (type_of_expr e2) ty H0 y' H3.  
+                      set (y:= cast ty (type_of_expr e2) y') in *.
+                      destruct y. 
+                        { cbv [Binary.Bplus]; simpl; destruct (eqb s0 s2); auto.
+                        }
+                        { simpl in H4; discriminate.
+                        }
+                        { simpl in H4; discriminate.
+                        }
+                        { pose proof Binary.Bplus_correct (fprec ty) (femax ty) 
+                            (fprec_gt_0 _) (fprec_lt_femax _) (plus_nan _) Binary.mode_NE 
+                            (Binary.B754_finite (fprec ty) (femax ty) s0 m e e0)
+                            (Binary.B754_finite (fprec ty) (femax ty) s2 m0 e3 e4) H2 H4. 
+                            match goal with H: (if ?a then ?b else ?c) |- _ => destruct a end.
+                            { destruct H5 as (A & B & C). 
+                              pose proof is_finite_not_is_nan (fprec ty) 
+                                (Z.max (femax (type_of_expr e1)) (femax (type_of_expr e2)))
+                                (Binary.Bplus (fprec ty) (femax ty) (fprec_gt_0 ty) (fprec_lt_femax ty) 
+                                     (plus_nan ty) Binary.mode_NE (Binary.B754_finite (fprec ty) (femax ty) s0 m e e0)
+                                     (Binary.B754_finite (fprec ty) (femax ty) s2 m0 e3 e4)) B;
+                              auto.
+                            }
 
 
+  
 
 (* end - AEK additions for converting expressions withe exact division
 by powers of two. *)

--- a/vcfloat/FPLangOpt.v
+++ b/vcfloat/FPLangOpt.v
@@ -1073,7 +1073,11 @@ apply eqb_prop in NAN.
                   pose proof cast_not_is_nan (type_of_expr e1) ty H (fval env e1) NAN.
                   set (x:=(cast ty (type_of_expr e1) (fval env e1))) in *.
                   set (y:=(cast ty (type_of_expr e2) (fval env e2))) in *.
+                  set (z:=(B2 ty (Z.neg (to_power_2_pos y)))) in *.
                   unfold BMULT, BDIV, BINOP. symmetry. 
+
+                      destruct x; try discriminate.
+{ 
                   apply Bdiv_mult_inverse_finite; auto.
                   {    
                     apply Bexact_inverse_correct in EINV.
@@ -1084,80 +1088,135 @@ apply eqb_prop in NAN.
                     destruct EINV as (A & B & C & D & E).
                     apply is_finite_strict_finite; auto.
                     }
+{
+                    apply Bexact_inverse_correct in EINV.
+                    destruct EINV as (A & B & C & D & E).
+                    destruct z.
+                    { simpl in B; discriminate.
+                    }
+                    { simpl in B; discriminate.
+                    }
+                    { simpl in B; discriminate.
+                    }
+
+                    destruct y.
+                    { simpl in A; discriminate.
+                    }
+                    { simpl in A; discriminate.
+                    }
+                    { simpl in A; discriminate.
+                    }
+                    simpl in E; subst; auto.
+}
+                  apply Bdiv_mult_inverse_finite; auto.
+                  {    
+                    apply Bexact_inverse_correct in EINV.
+                    destruct EINV as (A & B & C & D & E).
+                    apply is_finite_strict_finite; auto.
+                    } 
+                    apply Bexact_inverse_correct in EINV.
+                    destruct EINV as (A & B & C & D & E).
+                    apply is_finite_strict_finite; auto.
+}
+
 clear FEQ.
          match goal with
                   |- binary_float_eqb (fval env (if ?b then _ else _)) _ = _ =>
                   destruct b eqn:FEQ
                 end.
                    {
-                simpl. rewrite ?andb_true_iff in FEQ; destruct FEQ as [FEQ FIN]. 
+                simpl. rewrite ?andb_true_iff in FEQ; destruct FEQ as [FEQ NAN]. 
                       unfold cast_lub_l.
                       unfold cast_lub_r.
-                      revert IHe1. revert FIN. 
+                      revert IHe1. revert NAN. 
            apply binary_float_eqb_eq in FEQ. subst. revert EINV.
                       generalize (fval env (fshift_div env e1)).
                       rewrite fshift_type_div.
 intros. 
 apply binary_float_eqb_eq in IHe1. subst.
-apply eqb_prop in FIN.
+apply eqb_prop in NAN.
                    apply binary_float_eqb_eq.
                   set (ty:=(type_lub (type_of_expr e1) (type_of_expr e2))) in *.
                   change (Z.max (femax (type_of_expr e1)) (femax (type_of_expr e2))) with (femax ty) in *.
                   pose proof type_lub_left (type_of_expr e1) (type_of_expr e2).
-                  pose proof cast_finite (type_of_expr e1) ty H (fval env e1) FIN.
+                  pose proof cast_not_is_nan (type_of_expr e1) ty H (fval env e1) NAN.
                   set (x:=(cast ty (type_of_expr e1) (fval env e1))) in *.
                   set (y:=(cast ty (type_of_expr e2) (fval env e2))) in *.
+                      replace (Z.of_N (N.of_nat (Pos.to_nat (to_inv_power_2 y)))) with  (Z.pos (to_inv_power_2 y)) in * by lia.
+                      set (z:=B2 ty (Z.pos (to_inv_power_2 y))) in *.
                   unfold BMULT, BDIV, BINOP. symmetry. 
+                     destruct x; try discriminate.
+{ 
                   apply Bdiv_mult_inverse_finite; auto.
                   {    
                     apply Bexact_inverse_correct in EINV.
                     destruct EINV as (A & B & C & D & E).
                     apply is_finite_strict_finite; auto.
                     } 
+                    apply Bexact_inverse_correct in EINV.
+                    destruct EINV as (A & B & C & D & E).
+                    apply is_finite_strict_finite; auto.
+                    }
 {
                     apply Bexact_inverse_correct in EINV.
                     destruct EINV as (A & B & C & D & E).
-                      replace (Z.of_N (N.of_nat (Pos.to_nat (to_inv_power_2 y)))) with  (Z.pos (to_inv_power_2 y)) in * by lia.
-                    apply is_finite_strict_finite; auto.
+                    destruct z.
+                    { simpl in B; discriminate.
                     }
-replace (Z.of_N (N.of_nat (Pos.to_nat (to_inv_power_2 y)))) with  (Z.pos (to_inv_power_2 y)) in * by lia.
-auto.
+                    { simpl in B; discriminate.
+                    }
+                    { simpl in B; discriminate.
+                    }
+
+                    destruct y.
+                    { simpl in A; discriminate.
+                    }
+                    { simpl in A; discriminate.
+                    }
+                    { simpl in A; discriminate.
+                    }
+                    simpl in E; subst; auto.
 }
-clear FEQ.
-                      simpl. 
-                      unfold cast_lub_l.
-                      unfold cast_lub_r.
-                      revert IHe1. revert EINV. revert b.
-                      generalize (fval env (fshift_div env e1)).
-                      rewrite fshift_type_div.
-intros. 
-apply binary_float_eqb_eq in IHe1. subst.
-                   apply binary_float_eqb_eq. reflexivity.
+                  apply Bdiv_mult_inverse_finite; auto.
+                  {    
+                    apply Bexact_inverse_correct in EINV.
+                    destruct EINV as (A & B & C & D & E).
+                    apply is_finite_strict_finite; auto.
+                    } 
+                    apply Bexact_inverse_correct in EINV.
+                    destruct EINV as (A & B & C & D & E).
+                    apply is_finite_strict_finite; auto.
 }
-clear EINV.
- simpl. 
-                      unfold cast_lub_l.
-                      unfold cast_lub_r.
-                      revert IHe1. 
-                      generalize (fval env (fshift_div env e1)).
-                      rewrite fshift_type_div.
-intros. 
-apply binary_float_eqb_eq in IHe1. subst.
-                   apply binary_float_eqb_eq. reflexivity.
-}
-     clear E1 E2.
-      revert IHe1 IHe2.
+     revert IHe1.
       simpl.
       generalize (fval env (fshift_div env e1)).
-      generalize (fval env (fshift_div env e2)).
       repeat rewrite fshift_type_div.
       intros.
       apply binary_float_eqb_eq in IHe1. subst.
-      apply binary_float_eqb_eq in IHe2. subst.
       apply binary_float_eqb_eq.
       reflexivity.
-    }
-    clear ISDIV.
+}
+     revert IHe1.
+      simpl.
+      generalize (fval env (fshift_div env e1)).
+      repeat rewrite fshift_type_div.
+      intros.
+      apply binary_float_eqb_eq in IHe1. subst.
+      apply binary_float_eqb_eq.
+      reflexivity.
+}
+
+    revert IHe1 IHe2.
+    simpl.
+      generalize (fval env (fshift_div env e1)).
+      generalize (fval env (fshift_div env e2)).
+      repeat rewrite fshift_type_div.
+    intros.
+    apply binary_float_eqb_eq in IHe1. subst.
+    apply binary_float_eqb_eq in IHe2. subst.
+    apply binary_float_eqb_eq.
+    reflexivity.
+  }
     revert IHe1 IHe2.
     simpl.
       generalize (fval env (fshift_div env e1)).
@@ -1179,6 +1238,7 @@ simpl.
   apply binary_float_eqb_eq.
   reflexivity.
 Qed.
+
 Lemma fshift_div_correct env e:
   fval env (fshift_div env e) = eq_rect_r _ (fval env e) (fshift_type_div env e).
 Proof.

--- a/vcfloat/FPLangOpt.v
+++ b/vcfloat/FPLangOpt.v
@@ -1303,222 +1303,31 @@ forall b : binop,
 is_nan_expr env (Binop b e1 e2) = 
 Binary.is_nan _ _ (fval env (Binop b e1 e2)).
 Proof.
+Admitted.
+
+Lemma is_nan_expr_correct_unop env (e1: expr):
+forall b : unop, 
+is_nan_expr env (Unop b e1) = 
+Binary.is_nan _ _ (fval env (Unop b e1)).
+Proof.
+Admitted.
+
+Lemma is_nan_expr_correct env (e: expr):
+is_nan_expr env e = 
+Binary.is_nan _ _ (fval env e).
+Proof. 
 induction e.
 { simpl; auto.
 }
 { simpl; auto.
+}   
+{ apply is_nan_expr_correct_binop.
 }
-{ destruct b.
-  { destruct op.
-      { simpl. 
-        unfold cast_lub_r.
-        unfold cast_lub_l.
-        destruct (is_nan_expr env e1).
-          { destruct (is_nan_expr env e2).
-            {
-              unfold BPLUS, BINOP.
-              symmetry in IHe1. symmetry in IHe2. 
-              pose proof type_lub_left (type_of_expr e1) (type_of_expr e2).
-              pose proof type_lub_right (type_of_expr e1) (type_of_expr e2).
-              set (ty:=(type_lub (type_of_expr e1) (type_of_expr e2))) in *.
-              pose proof cast_is_nan (type_of_expr e1)
-              ty H (fval env e1) IHe1.
-              pose proof cast_is_nan (type_of_expr e2)
-              ty H0 (fval env e2) IHe2.
-              set (x:= cast ty (type_of_expr e1) (fval env e1)) in *.
-              set (y:= cast ty (type_of_expr e2) (fval env e2)) in *.
-              destruct x.
-                { simpl in H1; discriminate.
-                }
-                { simpl in H1; discriminate.
-                }
-                { destruct y.
-                  { simpl in H2; discriminate.
-                  }
-                  { simpl in H2; discriminate.
-                  }
-                  { cbv [Binary.Bplus]; simpl; auto.
-                  }
-                    simpl in H2; discriminate.
-                }
-                { simpl in H1; discriminate.
-                }
-              }
-                unfold BPLUS, BINOP.
-                symmetry in IHe1. symmetry in IHe2. 
-                pose proof type_lub_left (type_of_expr e1) (type_of_expr e2).
-                set (ty:=(type_lub (type_of_expr e1) (type_of_expr e2))) in *.
-                pose proof cast_is_nan (type_of_expr e1)
-                ty H (fval env e1) IHe1.
-                set (x:= cast ty (type_of_expr e1) (fval env e1)) in *.
-                set (y:= cast ty (type_of_expr e2) (fval env e2)) in *.
-                destruct x.
-                  { simpl in H0; discriminate.
-                  }
-                  { simpl in H0; discriminate.
-                  }
-                  { cbv [Binary.Bplus]; simpl; auto.
-                  }
-                  { simpl in H0; discriminate.
-                  }
-          }
-          { destruct (is_nan_expr env e2).
-            {
-              unfold BPLUS, BINOP.
-              symmetry in IHe1. symmetry in IHe2. 
-              pose proof type_lub_right (type_of_expr e1) (type_of_expr e2).
-              set (ty:=(type_lub (type_of_expr e1) (type_of_expr e2))) in *.
-              pose proof cast_is_nan (type_of_expr e2)
-              ty H (fval env e2) IHe2.
-              set (x:= cast ty (type_of_expr e1) (fval env e1)) in *.
-              set (y:= cast ty (type_of_expr e2) (fval env e2)) in *.
-              destruct x. 
-                { destruct y.
-                  { simpl in H0; discriminate.
-                  }
-                  { simpl in H0; discriminate.
-                  }
-                  { cbv [Binary.Bplus]; simpl; auto.
-                  }
-                  { simpl in H0; discriminate.
-                  }
-                } 
-                { destruct y.
-                  { simpl in H0; discriminate.
-                  }
-                  { simpl in H0; discriminate.
-                  }
-                  { cbv [Binary.Bplus]; simpl; auto.
-                  }
-                  { simpl in H0; discriminate.
-                  }
-                }
-                { destruct y.
-                  { simpl in H0; discriminate.
-                  }
-                  { simpl in H0; discriminate.
-                  }
-                  { cbv [Binary.Bplus]; simpl; auto.
-                  }
-                  { simpl in H0; discriminate.
-                  }
-                }
-                { destruct y.
-                  { simpl in H0; discriminate.
-                  }
-                  { simpl in H0; discriminate.
-                  }
-                  { cbv [Binary.Bplus]; simpl; auto.
-                  }
-                  { simpl in H0; discriminate.
-                  }
-                }
-            }
-              unfold BPLUS, BINOP.
-              symmetry in IHe1. symmetry in IHe2. 
-              simpl.
-symmetry. apply is_nan_plus; auto.
-              pose proof type_lub_left (type_of_expr e1) (type_of_expr e2).
-              pose proof type_lub_right (type_of_expr e1) (type_of_expr e2).
-              set (ty:=(type_lub (type_of_expr e1) (type_of_expr e2))) in *.
-              destruct (fval env e1).
-              { 
-                set (x':=(Binary.B754_zero (fprec (type_of_expr e1)) (femax (type_of_expr e1)) s)) in *.
-                assert (Binary.is_finite (fprec (type_of_expr e1)) (femax (type_of_expr e1)) x' = true) by
-                  (simpl;auto).
-                pose proof cast_finite (type_of_expr e1) ty H x' H1.  
-                set (x:= cast ty (type_of_expr e1) x') in *.
-                destruct x. 
-                  { 
-                  destruct (fval env e2).
-                   {  
-                      set (y':=(Binary.B754_zero (fprec (type_of_expr e2)) (femax (type_of_expr e2)) s1)) in *.
-                      assert (Binary.is_finite (fprec (type_of_expr e2)) (femax (type_of_expr e2)) y' = true) by
-                        (simpl;auto).
-                      pose proof cast_finite (type_of_expr e2) ty H0 y' H3.  
-                      set (y:= cast ty (type_of_expr e2) y') in *.
-                      destruct y. 
-                        { cbv [Binary.Bplus]; simpl; destruct (eqb s0 s2); auto.
-                        }
-                        { simpl in H4; discriminate.
-                        }
-                        { simpl in H4; discriminate.
-                        }
-                        { cbv [Binary.Bplus]; simpl; auto. 
-                        }
-                    }
-                    {
-                      set (y':=(Binary.B754_infinity (fprec (type_of_expr e2)) (femax (type_of_expr e2)) s1)) in *.
-                      assert (Binary.is_finite (fprec (type_of_expr e2)) (femax (type_of_expr e2)) y' = false) by
-                        (simpl;auto).
-                      pose proof cast_not_is_nan (type_of_expr e2) ty H0 y' IHe2.  
-                      pose proof cast_inf (type_of_expr e2) ty H0 y' H3.  
-                      set (y:= cast ty (type_of_expr e2) y') in *.
-                      destruct y. 
-                        { simpl in H5; discriminate.
-                        }
-                        { cbv [Binary.Bplus]; simpl; auto.
-                        }
-                        { simpl in H4; discriminate.
-                        }
-                        { simpl in H5; discriminate.
-                        }
-                     } 
-                     { simpl in IHe2; discriminate. 
-                     }
-                     {
-                      set (y':=(Binary.B754_finite (fprec (type_of_expr e2)) (femax (type_of_expr e2)) s1 m e e0))in *.
-                      assert (Binary.is_finite (fprec (type_of_expr e2)) (femax (type_of_expr e2)) y' = true) by
-                        (simpl;auto).
-                      pose proof cast_finite (type_of_expr e2) ty H0 y' H3.  
-                      set (y:= cast ty (type_of_expr e2) y') in *.
-                      destruct y. 
-                        { cbv [Binary.Bplus]; simpl; destruct (eqb s0 s2); auto.
-                        }
-                        { simpl in H4; discriminate.
-                        }
-                        { simpl in H4; discriminate.
-                        }
-                        { cbv [Binary.Bplus]; simpl; auto. 
-                        }
-                      }
-                  }
-                  { simpl in H2; discriminate.
-                  }
-                  { simpl in H2; discriminate.
-                  } 
-                  destruct (fval env e2).
-                   {  
-                      set (y':=(Binary.B754_zero (fprec (type_of_expr e2)) (femax (type_of_expr e2)) s1)) in *.
-                      assert (Binary.is_finite (fprec (type_of_expr e2)) (femax (type_of_expr e2)) y' = true) by
-                        (simpl;auto).
-                      pose proof cast_finite (type_of_expr e2) ty H0 y' H3.  
-                      set (y:= cast ty (type_of_expr e2) y') in *.
-                      destruct y. 
-                        { cbv [Binary.Bplus]; simpl; destruct (eqb s0 s2); auto.
-                        }
-                        { simpl in H4; discriminate.
-                        }
-                        { simpl in H4; discriminate.
-                        }
-                        { pose proof Binary.Bplus_correct (fprec ty) (femax ty) 
-                            (fprec_gt_0 _) (fprec_lt_femax _) (plus_nan _) Binary.mode_NE 
-                            (Binary.B754_finite (fprec ty) (femax ty) s0 m e e0)
-                            (Binary.B754_finite (fprec ty) (femax ty) s2 m0 e3 e4) H2 H4. 
-                            match goal with H: (if ?a then ?b else ?c) |- _ => destruct a end.
-                            { destruct H5 as (A & B & C). 
-                              pose proof is_finite_not_is_nan (fprec ty) 
-                                (Z.max (femax (type_of_expr e1)) (femax (type_of_expr e2)))
-                                (Binary.Bplus (fprec ty) (femax ty) (fprec_gt_0 ty) (fprec_lt_femax ty) 
-                                     (plus_nan ty) Binary.mode_NE (Binary.B754_finite (fprec ty) (femax ty) s0 m e e0)
-                                     (Binary.B754_finite (fprec ty) (femax ty) s2 m0 e3 e4)) B;
-                              auto.
-                            }
+{ apply is_nan_expr_correct_unop.
+}
+Qed. 
 
-
-  
-
-(* end - AEK additions for converting expressions withe exact division
+(* end - AEK additions for converting expressions with exact division
 by powers of two. *)
 
 (* Erasure of rounding annotations *)

--- a/vcfloat/FPLangOpt.v
+++ b/vcfloat/FPLangOpt.v
@@ -757,7 +757,7 @@ Proof.
   apply fshift_correct'.
 Qed.
 
-(* BEGIN - A.E.K additions for converting expressions withe exact division
+(* begin - AEK additions for converting expressions withe exact division
 by powers of two. *)
 Definition to_power_2_pos {prec emax} (x: Binary.binary_float prec emax) :=
   let y := B2BigQ x in
@@ -1246,7 +1246,129 @@ Proof.
   apply binary_float_eqb_eq_strong.
   apply fshift_div_correct'.
 Qed.
-(* END - A.E.K additions for converting expressions withe exact division
+
+Fixpoint is_zero_expr (env: forall ty, V -> ftype ty) (e: FPLang.expr) {struct e}: bool :=
+  match e with
+    | Const ty f => 
+        let s:= Binary.Bsign (fprec (type_of_expr e)) (femax (type_of_expr e)) (fval env e) in
+        binary_float_eqb (Binary.B754_zero (fprec ty) (femax ty) s) f 
+    | Var ty i => 
+        let s:= Binary.Bsign (fprec (type_of_expr e)) (femax (type_of_expr e)) (fval env e) in
+        binary_float_eqb (Binary.B754_zero (fprec ty) (femax ty) s) (fval env e) 
+    | Binop b e1 e2 =>
+        let e1' := is_zero_expr env e1 in 
+        let e2' := is_zero_expr env e2 in (e1' && e2')
+    | Unop b e1 =>
+        let e1' := is_zero_expr env e1 in e1'
+  end.
+
+Lemma is_zero_expr_correct' env e:
+ binary_float_eqb (fval env e) (Binary.B754_zero (fprec (type_of_expr e)) (femax (type_of_expr e)) 
+ (Binary.Bsign (fprec (type_of_expr e)) (femax (type_of_expr e)) (fval env e) )) = 
+ (is_zero_expr env e).
+Proof.
+intros.
+induction e.
+{
+simpl. 
+destruct f; simpl; auto.
+}
+{
+simpl. 
+destruct (env ty i); simpl; auto.
+}
+{
+simpl.
+
+unfold cast_lub_r in *.
+unfold cast_lub_l in *.
+destruct (is_zero_expr env e2).
+{
+destruct (is_zero_expr env e1).
+{
+apply binary_float_eqb_eq in IHe1. 
+apply binary_float_eqb_eq in IHe2.
+simpl. apply binary_float_eqb_eq.
+rewrite  IHe1.
+rewrite  IHe2.
+set (ty := (type_lub (type_of_expr e1) (type_of_expr e2))) in *.
+destruct b.
+{
+destruct op.
+{
+simpl. unfold BPLUS, BINOP.
+set (x:=(cast ty (type_of_expr e1)
+     (Binary.B754_zero (fprec (type_of_expr e1)) (femax (type_of_expr e1))
+        (Binary.Bsign (fprec (type_of_expr e1)) (femax (type_of_expr e1)) (fval env e1)))))
+in *.
+set (y:=(cast ty (type_of_expr e2)
+     (Binary.B754_zero (fprec (type_of_expr e2)) (femax (type_of_expr e2))
+        (Binary.Bsign (fprec (type_of_expr e2)) (femax (type_of_expr e2)) (fval env e2)))))
+in *.
+pose proof 
+(Binary.Bplus_correct _ _
+ (fprec_gt_0 ty) (fprec_lt_femax _) 
+(plus_nan _) Binary.mode_NE ) x y
+.
+pose proof type_lub_left (type_of_expr e1) (type_of_expr e2).
+pose proof cast_finite ty (type_of_expr e2).
+}
+{
+simpl. 
+
+
+destruct (env ty i); simpl; auto. 
+simpl in H. 
+
+Fixpoint is_nan_expr env (e: FPLang.expr): bool :=
+  match e with
+  Unop (Rounded1 SQRT None) e1 => 
+    let e1' := is_nan_expr e1 in 
+      eqb (Binary.Bsign _ _ (fval env e1')) false
+  | Binop (Rounded2 DIV None) e1 e2 => 
+    let e1' := is_nan_expr e1 in 
+    let e2' := is_nan_expr e2 in 
+    let b1 := eqb (Binary.is_finite_strict _ _ (fval env e2)) true in
+    let b2 := eqb (Binary.is_nan _ _ (fval env e1)) false in
+    b1 && b2
+  | _ => true
+end
+.
+
+  match e with
+    | Binop b e1 e2 =>
+      let e'1 := fshift_div env e1 in
+      let e'2 := fshift_div env e2 in
+      if binop_eqb b (Rounded2 DIV None) then
+      let ty := type_lub (type_of_expr e'1) (type_of_expr e'2) in
+      match (fcval_nonrec e'2) with
+            | Some c2' =>
+                let c2 := cast ty _ c2' in
+                match (Bexact_inverse (fprec ty) (femax ty) (fprec_gt_0 ty) (fprec_lt_femax ty) c2) with
+                  | Some z' => 
+                    let nan := (eqb (Binary.is_nan _ _ (fval env e'1)) false) in 
+                    let n1 := to_power_2_pos c2 in
+                    if (binary_float_eqb z' (B2 ty (Z.neg n1))) && nan
+                    then Unop (Exact1 (InvShift n1 true)) (Unop (CastTo ty None) e'1)
+                    else
+                    let n2 := to_inv_power_2 c2 in
+                    if (binary_float_eqb z' (B2 ty (Z.pos n2))) && nan
+                    then Unop (Exact1 (Shift (N.of_nat (Pos.to_nat n2)) true)) (Unop (CastTo ty None) e'1)
+                    else Binop b e'1 e'2
+                  | None => Binop b e'1 e'2
+                end
+             | None => Binop b e'1 e'2
+         end
+      else
+        Binop b e'1 e'2
+    | Unop b e => Unop b (fshift_div env e)
+    | _ => e
+  end.
+
+
+
+
+(* end - AEK additions for converting expressions withe exact division
 by powers of two. *)
 
 (* Erasure of rounding annotations *)

--- a/vcfloat/FPLangOpt.v
+++ b/vcfloat/FPLangOpt.v
@@ -1250,12 +1250,11 @@ Qed.
 Require Import Reals.ROrderedType.
 
 Definition is_zero_expr (env: forall ty, V -> ftype ty) (e: FPLang.expr)
- : bool := Reqb (rval env e) 0%R.
-
-Definition Rltb (x y : R) := match total_order_T x y with
-                            | inleft (left _) => true
-                            | _ => false
-                            end.
+ : bool :=  
+match (fval env e) with
+| Binary.B754_zero _ _ b1 => true
+| _ => false
+end.
 
 Fixpoint is_nan_expr (env: forall ty, V -> ftype ty) (e: expr)
 {struct e}: bool := 
@@ -1273,7 +1272,7 @@ Fixpoint is_nan_expr (env: forall ty, V -> ftype ty) (e: expr)
             be1' || be2' end
     | Unop b e1 => 
         match b with (Rounded1 SQRT None) => 
-        Rltb (rval env e) 0%R
+          Binary.Bsign _ _ (fval env e)
         |_ => is_nan_expr env e1 end
   end.
 

--- a/vcfloat/FPLangOpt.v
+++ b/vcfloat/FPLangOpt.v
@@ -1277,8 +1277,31 @@ Fixpoint is_nan_expr (env: forall ty, V -> ftype ty) (e: expr)
         |_ => is_nan_expr env e1 end
   end.
 
-Lemma is_nan_expr_correct env (e:FPLang.expr):
-is_nan_expr env e = Binary.is_nan _ _ (fval env e).
+Lemma is_nan_plus (env: forall ty, V -> ftype ty) (e1 e2:FPLang.expr):
+Binary.is_nan _ _ (fval env e1) = false -> 
+Binary.is_nan _ _ (fval env e2) = false -> 
+Binary.is_nan _ _ (fval env (Binop (Rounded2 PLUS None) e1 e2)) = false.
+Proof.
+Admitted.
+
+Lemma is_nan_minus (env: forall ty, V -> ftype ty) (e1 e2:FPLang.expr):
+Binary.is_nan _ _ (fval env e1) = false -> 
+Binary.is_nan _ _ (fval env e2) = false -> 
+Binary.is_nan _ _ (fval env (Binop (Rounded2 MINUS None) e1 e2)) = false.
+Proof.
+Admitted.
+
+Lemma is_nan_mult (env: forall ty, V -> ftype ty) (e1 e2:FPLang.expr):
+Binary.is_nan _ _ (fval env e1) = false -> 
+Binary.is_nan _ _ (fval env e2) = false -> 
+Binary.is_nan _ _ (fval env (Binop (Rounded2 MULT None) e1 e2)) = false.
+Proof.
+Admitted.
+
+Lemma is_nan_expr_correct_binop env (e1 e2:FPLang.expr):
+forall b : binop, 
+is_nan_expr env (Binop b e1 e2) = 
+Binary.is_nan _ _ (fval env (Binop b e1 e2)).
 Proof.
 induction e.
 { simpl; auto.
@@ -1393,6 +1416,8 @@ induction e.
             }
               unfold BPLUS, BINOP.
               symmetry in IHe1. symmetry in IHe2. 
+              simpl.
+symmetry. apply is_nan_plus; auto.
               pose proof type_lub_left (type_of_expr e1) (type_of_expr e2).
               pose proof type_lub_right (type_of_expr e1) (type_of_expr e2).
               set (ty:=(type_lub (type_of_expr e1) (type_of_expr e2))) in *.

--- a/vcfloat/FPLangOpt.v
+++ b/vcfloat/FPLangOpt.v
@@ -955,10 +955,6 @@ destruct H.
 apply Z.eqb_eq in H, H0. 
                   unfold cast_lub_l.
                   unfold cast_lub_r.
-destruct H. 
-apply eqb in H0. 
-                  apply type_eqb_eq in H.
-
                   set (ty:=(type_lub (type_of_expr e1) (type_of_expr e2))) in *.
                   change (Z.max (femax (type_of_expr e1)) (femax (type_of_expr e2))) with (femax ty) in *.
                   set (x:=(cast ty (type_of_expr e1) (fval env e1))) in *.
@@ -973,6 +969,9 @@ apply eqb in H0.
                     unfold BMULT, BDIV, BINOP. symmetry. 
                     rewrite FEQ in EINV. 
                     pose proof Float32.div_mul_inverse.
+subst.
+rewrite H in EINV.  
+
 assert (type_eq_dec float32 Tsingle).
 unfold float32, Bits.binary32 in H0.
 cbv [type_of_expr].

--- a/vcfloat/FPLangOpt.v
+++ b/vcfloat/FPLangOpt.v
@@ -1277,7 +1277,7 @@ Fixpoint is_nan_expr (env: forall ty, V -> ftype ty) (e: expr)
         |_ => is_nan_expr env e1 end
   end.
 
-Lemma not_is_nan_correct env (e:FPLang.expr):
+Lemma is_nan_expr_correct env (e:FPLang.expr):
 is_nan_expr env e = Binary.is_nan _ _ (fval env e).
 Proof.
 induction e.

--- a/vcfloat/FPLangOpt.v
+++ b/vcfloat/FPLangOpt.v
@@ -911,7 +911,13 @@ Proof.
         simpl in f.
         inversion E1; clear E1; subst.
         simpl in IHe1.
-        simpl.
+(* replace simpl with the following so as to not simpl in 
+matches on fprec and femax *)
+match goal with |- context [type_of_expr (Const ?ty ?f)] =>
+ set (m := type_of_expr (Const ty f));
+simpl in m; subst m; auto
+end.
+(* end replace simpl *)
         intros.
         subst.
         apply binary_float_eqb_eq in IHe1.
@@ -924,7 +930,13 @@ Proof.
         simpl in f.
         inversion E2; clear E2; subst.
         simpl in IHe2.
-        simpl.
+(* replace simpl with the following so as to not simpl in 
+matches on fprec and femax *)
+match goal with |- context [type_of_expr (Const ?ty ?f)] =>
+ set (m := type_of_expr (Const ty f));
+simpl in m; subst m; auto
+end.
+(* end replace simpl *)
         intros.
         subst.
         apply binary_float_eqb_eq in IHe2.
@@ -940,11 +952,7 @@ Proof.
                   rewrite ?orb_true_iff in FEQ. 
                   rewrite ?andb_true_iff in FEQ. destruct FEQ. 
 destruct H. 
-apply eqb_eq in H. 
-
-
-destruct H. 
-apply Z.eqb_eq in H. 
+apply Z.eqb_eq in H, H0. 
                   unfold cast_lub_l.
                   unfold cast_lub_r.
 destruct H. 

--- a/vcfloat/Test.v
+++ b/vcfloat/Test.v
@@ -301,15 +301,16 @@ match goal with |- eval_cond2 (mk_env ?bmap ?vmap) _ _ =>
   rewrite ?power_RZ_inv  in * by lra;
    rewrite <- ?powerRZ_add in * by lra;
    simpl Z.add;
- repeat
+repeat
   match goal with |- context [mk_env bmap vmap ?ty ?v'] =>
        match goal with H: Maps.PTree.get ?v vmap = _ |- _ =>
          change (mk_env bmap vmap ty v') with (mk_env bmap vmap ty v);
          let x := fresh "x" in set (x := mk_env _ vmap _ v); 
-         hnf in x; (* ; rewrite H in x;  *)
+         hnf in x; 
         let jj := fresh "jj" in 
          set (jj := Maps.PTree.get v vmap) in *; clearbody jj; subst jj;
-             compute in x; subst x
+             compute in x; subst x;
+         try (cbv in H; inversion H; clear H; subst)
   end end;
  repeat change (B2R (fprec ?x) _) with (FT2R x);
  try apply lesseq_less_or_eq;


### PR DESCRIPTION
FPLangOpt.fshift_div enables optimization of expressions that have division by powers of two; not previously handled by FPLangOpt.fshift. In particular, on an expression E  with divisions by powers of two, FPLangOpt.fshift_div  produces an expression E* with exact inverse shifts by powers of two. 

FPLang.fval takes exact inverse shifts to multiplication by inverse powers of two, so in order to prove equality over the floats between E and E* we need to know that the dividends in divisions in E are not NaNs. These non NaN obligations are left whenever FPLangOpt.fshift_div is applied.  There are some admitted proofs for lemmas that help with these obligations in FPLangOpt. 